### PR TITLE
montage mip now listens to z-radius, and fix quant indexing bug

### DIFF
--- a/eats_worm/Curator.py
+++ b/eats_worm/Curator.py
@@ -429,6 +429,7 @@ class Curator:
         self.update_trace_icons()
 
     def log_curate(self):
+        print('Logging curation...')
         self.do_hacks()
         self.curate['last'] = self.ind
         self.curate["contrast_min"], self.curate["contrast_max"] = self.min, self.max

--- a/eats_worm/Extractor.py
+++ b/eats_worm/Extractor.py
@@ -63,9 +63,9 @@ def background_subtraction_quant_function(im, spool, t, frames, quant_radius=3, 
     intensities = [np.NaN] * len(spool.threads)
     positions = spool.get_positions_t(t, indices=threads_to_quantify)
     positions = np.rint(np.copy(positions)).astype(int)
-    max_z = len(frames) - 1
-    max_x = im.shape[1] - 1
-    max_y = im.shape[2] - 1
+    max_z = len(frames) # in case of max_x, max_y, max_z, we're using these as indices so don't subtract 1 because slicing is exclusive 
+    max_x = im.shape[1]
+    max_y = im.shape[2]
     pos_z, pos_x, pos_y = positions.T
 
     pos_mask = np.zeros(im.shape, dtype=int)


### PR DESCRIPTION
I noticed that ROIs centered on the last z plane of an XYZT recording weren't being quantified. Although position of neuron center wasn't occluded by any adjacent neurons and z-quantification-radius was set to 0, timeseries for neurons centered on the last z-plane were zero.

I went to background_subtraction_quant_function and looked through the code. When setting the mask that would eventually be used for quantification, indexing of the z in the mask was implemented with z_starts[i]:z_stops[i].
z_stops is defined as the minimum of [z_maxes, pos_z + quant_z_radius + 1]
z_maxes is defined as np.array([max_z] * len(pos_z))
and max_z is max_z = len(frames) - 1

So here we're using z-plane index for our slicing, however our second slice bound is exclusive. Like if there are 12 total z planes, indexing a neuron in the final zplane would evaluate to [11:11] returning an empty array.

Solution was to remove the -1 on max_z. I applied the same fix to x and y which should be experiencing the same issue, tested on a few recordings which came out right as far as I can tell.

Merging for convenience